### PR TITLE
Add `getBoth` method for record destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,25 @@ void main() {
 }
 ```
 
+#### Handling the Result with `getBoth` (from Dart 3)
+
+Returns a record containing both success and error values,
+with one of them being null.
+This allows for easy destructuring using Dart 3's record patterns.
+
+```dart
+void main() {
+    final result = getSomethingPretty();
+    final (:success, :error) = result.getBoth();
+
+    if (success != null) {
+      print('Operation succeeded with: $success');
+    } else {
+      print('Operation failed with: $error');
+    }
+}
+```
+
 ### Transforming a Result
 
 #### Mapping success value with `map`

--- a/lib/src/result_dart_base.dart
+++ b/lib/src/result_dart_base.dart
@@ -110,6 +110,15 @@ sealed class ResultDart<S extends Object, F extends Object> {
     G Function(S success) onSuccess,
     W Function(F failure) onFailure,
   );
+
+  /// Returns a record containing both success and error values,
+  /// with one of them being null.
+  ///
+  /// This allows for easy destructuring using Dart 3's record patterns.
+  ///
+  /// Example:
+  /// final (:success, :error) = result.getBoth();
+  ({S? success, F? error}) getBoth();
 }
 
 /// Success Result.
@@ -259,6 +268,11 @@ final class Success<S extends Object, F extends Object> //
       (f) => Failure(failure),
     );
   }
+
+  @override
+  ({S? success, F? error}) getBoth() {
+    return (success: _success, error: null);
+  }
 }
 
 /// Error Result.
@@ -404,5 +418,10 @@ final class Failure<S extends Object, F extends Object> //
       (s) => Success(success),
       (f) => Failure(failure),
     );
+  }
+
+  @override
+  ({S? success, F? error}) getBoth() {
+    return (success: null, error: _failure);
   }
 }

--- a/test/src/result_dart_base_test.dart
+++ b/test/src/result_dart_base_test.dart
@@ -8,4 +8,22 @@ void main() {
     expect(result, isA<Success<int, String>>());
     expect(result.getOrThrow(), 1);
   });
+  group('getBoth', () {
+    test('should return a record with success value and null error on Success',
+        () {
+      final result = Success<String, Exception>('success');
+      final (:success, :error) = result.getBoth();
+      expect(success, 'success');
+      expect(error, isNull);
+    });
+
+    test('should return a record with null success and error value on Failure',
+        () {
+      final exception = Exception('failure');
+      final result = Failure<String, Exception>(exception);
+      final (:success, :error) = result.getBoth();
+      expect(success, isNull);
+      expect(error, exception);
+    });
+  });
 }


### PR DESCRIPTION
Add a new method that returns a record with success and error values for destructuring.
Include documentation and tests for the new functionality.

## Summary by Sourcery

Introduce a getBoth method to Result that returns a record containing both success and error values for easy destructuring using Dart 3 record patterns

New Features:
- Add getBoth method on Result to return a Dart 3 record with optional success and error fields

Documentation:
- Document getBoth usage in README with example code for record destructuring

Tests:
- Add tests verifying getBoth returns correct record for Success and Failure cases